### PR TITLE
Issue-5 - JS error will occur when using the URI constructor with a protocol handler like tel or mailto

### DIFF
--- a/src/Uri.js
+++ b/src/Uri.js
@@ -256,8 +256,7 @@ class Uri {
 	 */
 	maybeAddProtocolAndHostname_(opt_uri) {
 		var url = opt_uri;
-		if (opt_uri.indexOf('://') === -1 &&
-			opt_uri.indexOf('javascript:') !== 0) { // jshint ignore:line
+		if (opt_uri.indexOf('://') === -1) {
 
 			url = Uri.DEFAULT_PROTOCOL;
 			if (opt_uri[0] !== '/' || opt_uri[1] !== '/') {
@@ -281,6 +280,11 @@ class Uri {
 					break;
 				default:
 					url += opt_uri;
+
+					var uriScheme = opt_uri.substr(0, opt_uri.indexOf(':'));
+					if (uriScheme && uriScheme.indexOf('localhost') === -1) {
+						url = opt_uri;
+					}
 			}
 		}
 		return url;

--- a/test/Uri.js
+++ b/test/Uri.js
@@ -59,6 +59,11 @@ describe('Uri', function() {
 		assert.strictEqual('tel:', uri.getProtocol());
 	});
 
+	it('should support uri schemes that include numerical values', function() {
+		var uri = new Uri('pkcs11:hostname');
+		assert.strictEqual('pkcs11:', uri.getProtocol());
+	});
+
 	it('should support uri schemes that uses hyphen', function() {
 		var uri = new Uri('ms-excel:hostname');
 		assert.strictEqual('ms-excel:', uri.getProtocol());

--- a/test/Uri.js
+++ b/test/Uri.js
@@ -54,9 +54,24 @@ describe('Uri', function() {
 		assert.strictEqual('8080', uri.getPort());
 	});
 
-	it('should support all types of uri schemes', function() {
-		var uri = new Uri('test:hostname');
-		assert.strictEqual('test:', uri.getProtocol());
+	it('should support useful types of uri schemes like "tel"', function() {
+		var uri = new Uri('tel:hostname');
+		assert.strictEqual('tel:', uri.getProtocol());
+	});
+
+	it('should support uri schemes that uses hyphen', function() {
+		var uri = new Uri('ms-excel:hostname');
+		assert.strictEqual('ms-excel:', uri.getProtocol());
+	});
+
+	it('should support uri schemes that uses period', function() {
+		var uri = new Uri('iris.beep:hostname');
+		assert.strictEqual('iris.beep:', uri.getProtocol());
+	});
+
+	it('should support uri schemes that uses plus', function() {
+		var uri = new Uri('some+scheme:hostname');
+		assert.strictEqual('some+scheme:', uri.getProtocol());
 	});
 
 	it('should support set port on uri', function() {

--- a/test/Uri.js
+++ b/test/Uri.js
@@ -48,8 +48,19 @@ describe('Uri', function() {
 		assert.strictEqual('', uri.getOrigin());
 	});
 
+	it('should set procotol http: on localhost uri', function() {
+		var uri = new Uri('localhost:8080');
+		assert.strictEqual('http:', uri.getProtocol());
+		assert.strictEqual('8080', uri.getPort());
+	});
+
+	it('should support all types of uri schemes', function() {
+		var uri = new Uri('test:hostname');
+		assert.strictEqual('test:', uri.getProtocol());
+	});
+
 	it('should support set port on uri', function() {
-		var uri = new Uri('hostname:8080');
+		var uri = new Uri('http://hostname:8080');
 		assert.strictEqual('8080', uri.getPort());
 		uri.setPort('81');
 		assert.strictEqual('81', uri.getPort());

--- a/test/Uri.js
+++ b/test/Uri.js
@@ -59,22 +59,22 @@ describe('Uri', function() {
 		assert.strictEqual('tel:', uri.getProtocol());
 	});
 
+	it('should support uri schemes that include hyphens', function() {
+		var uri = new Uri('ms-excel:hostname');
+		assert.strictEqual('ms-excel:', uri.getProtocol());
+	});
+
 	it('should support uri schemes that include numerical values', function() {
 		var uri = new Uri('pkcs11:hostname');
 		assert.strictEqual('pkcs11:', uri.getProtocol());
 	});
 
-	it('should support uri schemes that uses hyphen', function() {
-		var uri = new Uri('ms-excel:hostname');
-		assert.strictEqual('ms-excel:', uri.getProtocol());
-	});
-
-	it('should support uri schemes that uses period', function() {
+	it('should support uri schemes that include periods', function() {
 		var uri = new Uri('iris.beep:hostname');
 		assert.strictEqual('iris.beep:', uri.getProtocol());
 	});
 
-	it('should support uri schemes that uses plus', function() {
+	it('should support uri schemes that include pluses', function() {
 		var uri = new Uri('some+scheme:hostname');
 		assert.strictEqual('some+scheme:', uri.getProtocol());
 	});

--- a/test/Uri.js
+++ b/test/Uri.js
@@ -48,7 +48,7 @@ describe('Uri', function() {
 		assert.strictEqual('', uri.getOrigin());
 	});
 
-	it('should set procotol http: on localhost uri', function() {
+	it('should set protocol http: on localhost uri', function() {
 		var uri = new Uri('localhost:8080');
 		assert.strictEqual('http:', uri.getProtocol());
 		assert.strictEqual('8080', uri.getPort());


### PR DESCRIPTION
@fernandosouza,

I made the changes to fix [issue-5](https://github.com/metal/metal-uri/issues/5).  

I'm somewhat unsure about the changes I made since it is working off a list of uri schemes to avoid.  The other way I was thinking of doing this was to create a whitelist of possible uris but the possible uri schemes are endless.