### PR TITLE
Detects invalid URLs and throws the expected TypeError exception when invalid

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -10,7 +10,16 @@ import parseFromAnchor from './parseFromAnchor';
  */
 function parse(opt_uri) {
 	if (isFunction(URL) && URL.length) {
-		return new URL(opt_uri);
+		const url = new URL(opt_uri);
+
+		// Safari Browsers will cap port to the max 16-bit unsigned integer (65535) instead
+		// of throwing a TypeError as per spec. It will still keep the port number in the
+		// href attribute, so we can use this mismatch to raise the expected exception.
+		if (url.port && url.href.indexOf(url.port) === -1) {
+			throw new TypeError(`${opt_uri} is not a valid URL`);
+		}
+
+		return url;
 	} else {
 		return parseFromAnchor(opt_uri);
 	}

--- a/src/parseFromAnchor.js
+++ b/src/parseFromAnchor.js
@@ -7,6 +7,11 @@
 function parseFromAnchor(opt_uri) {
 	var link = document.createElement('a');
 	link.href = opt_uri;
+
+	if(link.protocol === ':' || !/:/.test(link.href)) {
+		throw new TypeError(`${opt_uri} is not a valid URL`);
+	}
+
 	return {
 		hash: link.hash,
 		hostname: link.hostname,

--- a/test/parse.js
+++ b/test/parse.js
@@ -14,5 +14,11 @@ if (typeof URL !== 'undefined') {
 			assert.strictEqual('http:', uri.protocol);
 			assert.strictEqual('?a=1', uri.search);
 		});
+
+		it('should throw a TypeError exception on invalid URLs', function() {
+			assert.throws(function() {
+				parse('http://localhost:99999');
+			}, TypeError)
+		});
 	});
 }

--- a/test/parseFromAnchor.js
+++ b/test/parseFromAnchor.js
@@ -15,5 +15,11 @@ if (typeof URL !== 'undefined') {
 			assert.strictEqual('http:', uri.protocol);
 			assert.strictEqual('?a=1', uri.search);
 		});
+
+		it('should throw a TypeError exception on invalid URLs', function() {
+			assert.throws(function() {
+				parseFromAnchor('http://localhost:99999');
+			}, TypeError)
+		});
 	});
 }


### PR DESCRIPTION
Hey @eduardolundgren, @brunobasto, @fernandosouza, this is a tentative fix for #11.

- For the fallback, I've added the check used by the [`DOM-URL` polyfill](https://github.com/arv/DOM-URL-Polyfill/blob/master/src/url.js#L33)
- The native implementation in Safari is non-standard, and doesn't throw for overflowing ports, so I've added a simple check against the stored `href` to verify it is the same, although it might fail if the overflowing port contains the max port number... we can improve it a bit more if necessary