### PR TITLE
add more thorough check for invalid URIs

### DIFF
--- a/src/parseFromAnchor.js
+++ b/src/parseFromAnchor.js
@@ -1,6 +1,35 @@
 'use strict';
 
 /**
+ * Helper function to determine whether the given uri contains port section
+ * @param {string} uri String URI to check
+ */
+function isPortProvidedToURL(uri) {
+	return /:[0-9]+$/.test(uri);
+} 
+
+/** 
+ * Helper function to check whether the browser has invalidated
+ * the <a> element due incorrect URI. This vary across implementations
+ * and platforms hence the various attempts to assure the logic
+ * will work against all major browsers.
+ * @param {object} a Anchor typed DOMElement
+ */
+function isAnchorInvalidatedByBrowser(a) {
+	// try-catch clouse is required as IE11 throws Error when
+	// accessing either of these attributes when the URL is invalid
+	try {
+		if (':' === a.protocol) return true; 
+		if (!/:/.test(a.href)) return true;
+		if (isPortProvidedToURL(a.href) && '' === a.port) return true;
+	} catch (e) {
+		// re-throw any sort of exception as a TypeError
+		throw new TypeError(e.message);
+	}
+	return false;
+}
+
+/**
  * Parses the given uri string into an object.
  * @param {*=} opt_uri Optional string URI to parse
  */
@@ -8,7 +37,7 @@ function parseFromAnchor(opt_uri) {
 	var link = document.createElement('a');
 	link.href = opt_uri;
 
-	if(link.protocol === ':' || !/:/.test(link.href)) {
+	if (isAnchorInvalidatedByBrowser(link)) {
 		throw new TypeError(`${opt_uri} is not a valid URL`);
 	}
 

--- a/src/parseFromAnchor.js
+++ b/src/parseFromAnchor.js
@@ -5,7 +5,7 @@
  * @param {string} uri String URI to check
  */
 function isPortProvidedToURL(uri) {
-	return /:[0-9]+$/.test(uri);
+	return /:[0-9]+/.test(uri);
 } 
 
 /** 

--- a/test/parse.js
+++ b/test/parse.js
@@ -15,7 +15,7 @@ if (typeof URL !== 'undefined') {
 			assert.strictEqual('?a=1', uri.search);
 		});
 
-		it('should throw a TypeError exception on invalid URLs', function() {
+		it('should throw a TypeError exception if the port number exceeds 65535', function() {
 			assert.throws(function() {
 				parse('http://localhost:99999');
 			}, TypeError)


### PR DESCRIPTION
#### Disclaimer 
FF and IE appear to have implemented the built-in native URI parsing logic differently than the project's`parseFromAnchor` helper function expects and subsequently invoking this function with invalid URIs results in failing tests. 

#### Intent
To fix failing tests with FF and IE

#### Solution
- Added more sophisticated checks against validating the URI with virtual `<a>` element.

#### Tested
- IE
- FF
- Safari
- Chrome

